### PR TITLE
bugfix on the builder

### DIFF
--- a/src/M6Builder.cpp
+++ b/src/M6Builder.cpp
@@ -560,6 +560,11 @@ void M6Processor::Process(vector<fs::path>& inFiles, M6Progress& inProgress,
         if (inNrOfThreads > inFiles.size())
             inNrOfThreads = static_cast<uint32>(inFiles.size());
  */
+        for (uint32 i = 0; i < inNrOfThreads; ++i)
+            mFileThreads.create_thread(
+                [&inProgress, this]() { this->ProcessFile(inProgress); }
+            );
+
         for (fs::path& file : inFiles)
         {
             if (not (mException == std::exception_ptr()))
@@ -577,11 +582,6 @@ void M6Processor::Process(vector<fs::path>& inFiles, M6Progress& inProgress,
         mFileQueue.Put(fs::path());
 
         // Now all the input files have been added to the queue.
-
-        for (uint32 i = 0; i < inNrOfThreads; ++i)
-            mFileThreads.create_thread(
-                [&inProgress, this]() { this->ProcessFile(inProgress); }
-            );
 
         mFileThreads.join_all();
     }


### PR DESCRIPTION
Run the file threads first, before adding any files to the queue. This must prevent the queue from reaching the limit and keeping the main thread hanging forever.