### PR TITLE
Databank load error

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -94,7 +94,7 @@ OBJECTS = \
 	$(OBJDIR)/M6WSBlast.o \
 	$(OBJDIR)/M6WSSearch.o \
 
-all: mrs config/mrs-config.xml mrs.1 init.d/mrs run_tests
+all: mrs config/mrs-config.xml mrs.1 init.d/mrs
 
 checkcache: $(OBJDIR)/checkcache.o
 	$(CXX) -o $@ -I. $< $(LDFLAGS)
@@ -105,11 +105,9 @@ mrs: $(OBJECTS)
 
 unit_test_blast: unit-tests/M6TestBlast.cpp $(OBJDIR)/M6Blast.o \
 		$(OBJDIR)/M6Matrix.o $(OBJDIR)/M6Error.o $(OBJDIR)/M6Progress.o \
-		$(OBJDIR)/M6Utilities.o
+		$(OBJDIR)/M6Utilities.o $(OBJDIR)/M6Log.o $(OBJDIR)/M6Config.o
 	$(CXX) -o $@ -I src $^ $(LDFLAGS)
 
-run_tests: $(TESTS)
-	for test in $(TESTS); do ./$$test; done
 
 $(OBJDIR)/%.o: %.cpp | $(OBJDIR)
 	@ echo ">>" $<
@@ -155,7 +153,7 @@ INSTALLDIRS = \
 		-e 's|__CLUSTALO__|$(CLUSTALO)|g' \
 		$< > $@
 
-install: mrs config/mrs-config.xml mrs.1 init.d/mrs logrotate.d/mrs
+install: mrs config/mrs-config.xml mrs.1 init.d/mrs logrotate.d/mrs $(TESTS)
 	@ echo "Creating directories"
 	@ for d in $(INSTALLDIRS); do \
 		if [ ! -d $$d ]; then \
@@ -203,6 +201,7 @@ install: mrs config/mrs-config.xml mrs.1 init.d/mrs logrotate.d/mrs
 		echo ""; \
 		echo "Not overwriting /etc/logrotate.d/mrs file" ; \
 	  fi
+	@ for test in $(TESTS); do ./$$test; done
 
 DIST = mrs-$(VERSION)
 

--- a/config/mrs-config.xml.dist
+++ b/config/mrs-config.xml.dist
@@ -213,10 +213,10 @@
       <info>http://www.ebi.ac.uk/interpro/</info>
       <source fetch="ftp://ftp.ebi.ac.uk/pub/databases/interpro/54.0/" delete="false">interpro/interpro.xml.gz</source>
     </databank>
-    <databank id="oxford" parser="oxford" enabled="true" update="weekly" fasta="false">
+    <databank id="oxford" parser="oxford" enabled="false" update="never" fasta="false">
       <name>Oxford Human Mouse grid</name>
       <info>http://www.informatics.jax.org/</info>
-      <source fetch="ftp://ftp.informatics.jax.org/pub/reports" delete="false">oxford/HMD_Human3.rpt</source>
+      <source fetch="ftp://ftp.informatics.jax.org/pub/reports" delete="false">oxford/HMD_HumanPhenotype.rpt</source>
     </databank>
     <databank id="mimmap" parser="mimmap" enabled="true" update="never" fasta="false">
       <name>Mimmap, our view on genemap from OMIM</name>
@@ -235,7 +235,7 @@
       <info>http://pfam.sanger.ac.uk/</info>
       <source fetch="ftp://ftp.ebi.ac.uk/pub/databases/Pfam" delete="false">pfam/Pfam-A.full.gz</source>
     </databank>
-    <databank id="pfamb" parser="pfam" format="stockholm" enabled="true" update="weekly" fasta="false">
+    <databank id="pfamb" parser="pfam" format="stockholm" enabled="false" update="never" fasta="false">
       <aliases>
         <alias>pfam</alias>
       </aliases>

--- a/configure
+++ b/configure
@@ -381,7 +381,6 @@ END
 	
 	$header_check =<<END;
 #include "EXTERN.h"
-#include "perl.h"
 #include "XSUB.h"
 #include <iostream>
 int main() { std::cout << 1 << '\t' << 0; return 0; }


### PR DESCRIPTION
Disables the following databanks in mrs, because they cannot be built:
* oxford, because the file is unparsable with the current parser
* pfamb, because there are no input files on the source server (anymore?)

Also fixes some bugs that appear while building the docker image.