### PR TITLE
make all pieces of the pdbfinder2 sequence available as blast hits

### DIFF
--- a/parsers/pdbfinder.pm
+++ b/parsers/pdbfinder.pm
@@ -111,11 +111,13 @@ sub to_fasta
         {
             $chainid = $1;
         }
-        elsif ($line =~ /^\s*Sequence\s*:\s*(\w+)/)
+        elsif ($line =~ /^\s*Sequence\s*:\s*([\-\w]+)/)
         {
             my $seq = uc $1;
-            $seq =~ tr/ARNDCQEGHILKMFPSTWYVBZX//dc;
-            $seq{$chainid} = $seq;
+
+            my @seqs = $seq =~ m/[ARNDCQEGHILKMFPSTWYVBZX]+/g;
+
+            $seq{$chainid} = [@seqs];
         }
     }
 
@@ -124,8 +126,11 @@ sub to_fasta
     {
         foreach my $chain (keys %seq)
         {
-            my $seq = $seq{$chain};
-            $result .= ">gnl|$db|$id|$chain $title\n$seq\n";
+            my @seqs = @{$seq{$chain}};
+            foreach my $seq (@seqs)
+            {
+                $result .= ">gnl|$db|$id|$chain $title\n$seq\n";
+            }
         }
     }
 


### PR DESCRIPTION
only changes something if there are chain breaks in pdbfinder sequences